### PR TITLE
Added new GPG key used by HP for signing packages

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -73,7 +73,7 @@ class hp_mcp::repo (
             gpgcheck => 1,
             # gpgkey has to be a string value with an indented second line
             # per http://projects.puppetlabs.com/issues/8867
-            gpgkey   => "${yum_server}${gpg_path}hpPublicKey1024.pub\n    ${yum_server}${gpg_path}hpPublicKey2048.pub",
+            gpgkey   => "${yum_server}${gpg_path}hpPublicKey1024.pub\n    ${yum_server}${gpg_path}hpPublicKey2048.pub\n    ${yum_server}${gpg_path}hpPublicKey2048_key1.pub",
             baseurl  => "${yum_server}${yum_path}${mcp_version}/",
             priority => $hp_mcp::params::yum_priority,
             protect  => $hp_mcp::params::yum_protect,

--- a/spec/classes/hp_mcp_repo_spec.rb
+++ b/spec/classes/hp_mcp_repo_spec.rb
@@ -47,7 +47,8 @@ describe 'hp_mcp::repo', :type => 'class' do
           :enabled  => '1',
           :gpgcheck => '1',
           :gpgkey   => 'http://downloads.linux.hp.com/SDR/hpPublicKey1024.pub
-    http://downloads.linux.hp.com/SDR/hpPublicKey2048.pub',
+    http://downloads.linux.hp.com/SDR/hpPublicKey2048.pub
+    http://downloads.linux.hp.com/SDR/hpPublicKey2048_key1.pub',
           :baseurl  => 'http://downloads.linux.hp.com/SDR/repo/mcp/CentOS/$releasever/$basearch/current/',
           :priority => '50',
           :protect  => '0'
@@ -67,7 +68,8 @@ describe 'hp_mcp::repo', :type => 'class' do
           :enabled  => '1',
           :gpgcheck => '1',
           :gpgkey   => 'http://downloads.linux.hp.com/SDR/hpPublicKey1024.pub
-    http://downloads.linux.hp.com/SDR/hpPublicKey2048.pub',
+    http://downloads.linux.hp.com/SDR/hpPublicKey2048.pub
+    http://downloads.linux.hp.com/SDR/hpPublicKey2048_key1.pub',
           :baseurl  => 'http://downloads.linux.hp.com/SDR/repo/mcp/Oracle/$releasever/$basearch/current/',
           :priority => '50',
           :protect  => '0'


### PR DESCRIPTION
Hello

It looks like HP added new GPG key for signing their packages.
Search for "New GPG signatures are required for 2015!" http://downloads.linux.hp.com/SDR/

I need to use "http://downloads.linux.hp.com/hpPublicKey2048_key1.pub" as well when installing the packages.

Please check it.

PetrR
